### PR TITLE
Several modifcations ported upstream from the Metasploit Framework

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -4356,14 +4356,14 @@ module RbReadline
       def rl_getc(stream)
          while (@kbhit.Call == 0)
             # If there is no input, yield the processor for other threads
-            sleep(0.001)
+            sleep(@_keyboard_input_timeout)
          end
          c = @getch.Call
          alt = (@GetKeyState.call(VK_LMENU) & 0x80) != 0
          if c==0 || c==0xE0
             while (@kbhit.Call == 0)
                # If there is no input, yield the processor for other threads
-               sleep(0.001)
+               sleep(@_keyboard_input_timeout)
             end
             r = c.chr + @getch.Call.chr
          else


### PR DESCRIPTION
Most notably, we had some issues with 1.8/1.9 compatibility and Windows compatibility. Also, a few typos corrected.

PS, I can confirm ^R works now, which was a long-standing issue with us.  

We have some additional changes that we've made that I did not include here. They may be worth investigating at some point.
