### PR TITLE
Fix hanging bug when the completer finds a quote char

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -6074,6 +6074,12 @@ module RbReadline
          scan = 0
          pass_next = false
          while scan < _end
+            if !@rl_byte_oriented
+               scan = _rl_find_next_mbchar(@rl_line_buffer, scan, 1, MB_FIND_ANY)
+            else
+               scan += 1
+            end
+
             if (pass_next)
                pass_next = false
                next
@@ -6110,11 +6116,6 @@ module RbReadline
                else
                   found_quote |= RL_QF_OTHER_QUOTE
                end
-            end
-            if !@rl_byte_oriented
-               scan = _rl_find_next_mbchar(@rl_line_buffer, scan, 1, MB_FIND_ANY)
-            else
-               scan += 1
             end
          end
       end

--- a/test/test_completion.rb
+++ b/test/test_completion.rb
@@ -1,0 +1,42 @@
+require "test/unit"
+require "fileutils"
+require 'timeout'
+require "readline"
+
+class TestCompletion < Test::Unit::TestCase
+  include RbReadline
+
+  def setup
+    FileUtils.mkdir_p "completer_test_dir/a b"
+    @rl_completion_word_break_hook, @rl_char_is_quoted_p = nil
+    @rl_basic_quote_characters, @rl_special_prefixes = nil
+    @rl_completer_word_break_characters = Readline.basic_word_break_characters
+    @rl_completer_quote_characters = "\\"
+    @rl_byte_oriented = true
+  end
+
+  def teardown
+    FileUtils.rm_r "completer_test_dir"
+  end
+
+  def set_line_buffer(text)
+    @rl_line_buffer = text
+    @rl_point = @rl_line_buffer.size
+    @rl_line_buffer << 0.chr
+  end
+
+  def test__find_completion_word_doesnt_hang_on_completer_quote_character
+    set_line_buffer "completer_test_dir/a\\ b"
+
+    assert_nothing_raised do
+      Timeout::timeout(3) do
+        assert_equal([ "\000", true, "\000" ], _rl_find_completion_word)
+      end
+    end
+  end
+
+  def test__find_completion_word_without_quote_characters
+    set_line_buffer "completer_test_dir/a"
+    assert_equal([ "\000", false, "\000" ], _rl_find_completion_word)
+  end
+end


### PR DESCRIPTION
rb-readline would hit an infinite loop when the completer found a completer_quote_character in the line buffer. This fixes the bug by bringing the Ruby implementation closer to Readline 5.2 in C.

I've added a couple of simple unit tests. This isn't too pretty, but does at least provide some coverage against regressions and should be sufficient until we get some integrations tests up and running.

I've tested this on Fedora 14 and WIndows XP with both Ruby 1.8.7 and Ruby 1.9.2.
