### PR TITLE
Make sure filename quoting and dequoting methods are called

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -1146,8 +1146,9 @@ module RbReadline
             @users_dirname = @dirname.dup
          elsif (@rl_completion_found_quote && @rl_filename_dequoting_function)
             # delete single and double quotes
-            @temp = send(@rl_filename_dequoting_function,@users_dirname, @rl_completion_quote_character)
+            temp = send(@rl_filename_dequoting_function, @users_dirname, @rl_completion_quote_character)
             @users_dirname = temp
+            @dirname = @users_dirname.dup
          end
 
          @directory = Dir.new(@dirname)
@@ -1155,7 +1156,7 @@ module RbReadline
          # Now dequote a non-null filename.
          if (@filename && @filename.length>0 && @rl_completion_found_quote && @rl_filename_dequoting_function)
             # delete single and double quotes
-            temp = send(@rl_filename_dequoting_function,@filename, @rl_completion_quote_character)
+            temp = send(@rl_filename_dequoting_function, @filename, @rl_completion_quote_character)
             @filename = temp
          end
 

--- a/test/filesystem_completion_helper.rb
+++ b/test/filesystem_completion_helper.rb
@@ -1,0 +1,53 @@
+require "fileutils"
+
+module FilesystemCompletionHelper
+  SEP = File::SEPARATOR
+  COMP_TEST_DIR = "comp_test#{SEP}"
+  SUB_DIR = "#{COMP_TEST_DIR}a_sub_dir#{SEP}"
+  SUB_SUB_DIR = "#{SUB_DIR}another_sub_dir#{SEP}"
+  DIR_WITH_SPACES = "#{COMP_TEST_DIR}dir with spaces#{SEP}"
+  SUB_DIR_WITH_SPACES = "#{DIR_WITH_SPACES}sub dir with spaces#{SEP}"
+
+  # This creates:
+  #
+  #   comp_test/
+  #     abc
+  #     aaa
+  #     a_sub_dir/
+  #       abc
+  #       aaa
+  #       another_sub_dir/
+  #         aaa
+  #     dir with spaces/
+  #       filename with spaces
+  #       sub dir with spaces/
+  #         another filename with spaces
+  def setup_filesystem_for_completion
+    FileUtils.mkdir_p("#{SUB_SUB_DIR}")
+    FileUtils.mkdir_p("#{SUB_DIR_WITH_SPACES}")
+    @comp_test_dir = Dir.new COMP_TEST_DIR
+    @sub_dir = Dir.new SUB_DIR
+    @sub_sub_dir = Dir.new SUB_SUB_DIR
+    @dir_with_spaces = Dir.new DIR_WITH_SPACES
+    @sub_dir_with_spaces = Dir.new SUB_DIR_WITH_SPACES
+
+    FileUtils.touch("#{@comp_test_dir.path}abc")
+    FileUtils.touch("#{@comp_test_dir.path}aaa")
+    FileUtils.touch("#{@sub_dir.path}abc")
+    FileUtils.touch("#{@sub_dir.path}aaa")
+    FileUtils.touch("#{@sub_sub_dir.path}aaa")
+    FileUtils.touch("#{@dir_with_spaces.path}filename with spaces")
+    FileUtils.touch("#{@sub_dir_with_spaces.path}another filename with spaces")
+
+    # The previous Dir.new calls seem to cache the dir entries on Windows.
+    @comp_test_dir = Dir.new COMP_TEST_DIR
+    @sub_dir = Dir.new SUB_DIR
+    @sub_sub_dir = Dir.new SUB_SUB_DIR
+    @sub_dir_with_spaces = Dir.new SUB_DIR_WITH_SPACES
+    @dir_with_spaces = Dir.new DIR_WITH_SPACES
+  end
+
+  def teardown_filesystem_after_completion
+    FileUtils.rm_r(COMP_TEST_DIR)
+  end
+end

--- a/test/test_filename_completion_proc.rb
+++ b/test/test_filename_completion_proc.rb
@@ -1,31 +1,11 @@
 require 'test/unit'
 require 'fileutils'
-$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../lib/"
 require 'readline'
+require "#{File.expand_path(File.dirname(__FILE__))}/filesystem_completion_helper"
 
 class TC_FILENAME_COMPLETION_PROC < Test::Unit::TestCase
+  include FilesystemCompletionHelper
 
-  SEP = File::SEPARATOR
-  COMP_TEST_DIR = "comp_test#{SEP}"
-  SUB_DIR = "#{COMP_TEST_DIR}a_sub_dir#{SEP}"
-  SUB_SUB_DIR = "#{SUB_DIR}another_sub_dir#{SEP}"
-  DIR_WITH_SPACES = "#{COMP_TEST_DIR}dir with spaces#{SEP}"
-  SUB_DIR_WITH_SPACES = "#{DIR_WITH_SPACES}sub_dir with spaces#{SEP}"
-
-  # This creates:
-  #
-  #   comp_test/
-  #     abc
-  #     aaa
-  #     a_sub_dir/
-  #       abc
-  #       aaa
-  #       another_sub_dir/
-  #         aaa
-  #     dir with spaces/
-  #       filename with spaces
-  #       sub dir with spaces/
-  #         another filename with spaces
   def setup
     FileUtils.mkdir_p("#{SUB_SUB_DIR}")
     FileUtils.mkdir_p("#{SUB_DIR_WITH_SPACES}")
@@ -49,10 +29,11 @@ class TC_FILENAME_COMPLETION_PROC < Test::Unit::TestCase
     @sub_sub_dir = Dir.new SUB_SUB_DIR
     @dir_with_spaces = Dir.new DIR_WITH_SPACES
     @sub_dir_with_spaces = Dir.new SUB_DIR_WITH_SPACES
+    setup_filesystem_for_completion
   end
 
   def teardown
-    FileUtils.rm_r(COMP_TEST_DIR)
+    teardown_filesystem_after_completion
   end
 
   def test_listing_files_in_cwd


### PR DESCRIPTION
Currently, if an application defines @rl_filename_quoting_function and @rl_filename_dequoting_function, it will not behave as it should. Although both methods get called, a couple of problems mean that @fl_filename_dequoting_function is not used correctly. This patchset adds some tests and fixes the bugs.

One of the bugs is, as I mentioned in the commit notes, also a bug in some versions of GNU Readline (it exists in 5.2, 6.0 and 6.1 - it is fixed in 6.2).
