### PR TITLE
work for windows.

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -2102,7 +2102,7 @@ module RbReadline
 
     openname = File.expand_path(filename)
     begin
-      buffer = File.open(openname).read
+      buffer = File.open(openname).read.force_encoding("ASCII-8BIT")
     rescue
       return -1
     end
@@ -3126,7 +3126,7 @@ module RbReadline
           end
           line = @invisible_line
         end
-        line[out,@local_prompt_len] = @local_prompt
+        line[out,@local_prompt_len] = @local_prompt.force_encoding("ASCII-8BIT")
         out += @local_prompt_len
       end
       line[out,1] = 0.chr


### PR DESCRIPTION
rb-readline seems that don't work on windows.
I don't use cygwin always. I tried to set LANG environment ja_JP.UTF-8/ja_JP.SHIFT_JIS/C ...etc to work correctly. But don't fixed. it seems _rl_read_init_file should be pass arguments with ASCII-8BIT encoding.

```
C:/Ruby192/lib/ruby/gems/1.9.1/gems/rb-readline-0.4.0/lib/rbreadline.rb:2114:in `block in _rl_read_init_file': invalid byte sequence in Windows-31J (ArgumentError)
        from C:/Ruby192/lib/ruby/gems/1.9.1/gems/rb-readline-0.4.0/lib/rbreadline.rb:2112:in `each_line'
        from C:/Ruby192/lib/ruby/gems/1.9.1/gems/rb-readline-0.4.0/lib/rbreadline.rb:2112:in `_rl_read_init_file'
        from C:/Ruby192/lib/ruby/gems/1.9.1/gems/rb-readline-0.4.0/lib/rbreadline.rb:2078:in `rl_read_init_file'
        from C:/Ruby192/lib/ruby/gems/1.9.1/gems/rb-readline-0.4.0/lib/rbreadline.rb:2499:in `readline_initialize_everything'
        from C:/Ruby192/lib/ruby/gems/1.9.1/gems/rb-readline-0.4.0/lib/rbreadline.rb:3730:in `rl_initialize'
        from C:/Ruby192/lib/ruby/gems/1.9.1/gems/rb-readline-0.4.0/lib/rbreadline.rb:4737:in `readline'
        from C:/Ruby192/lib/ruby/gems/1.9.1/gems/rb-readline-0.4.0/lib/readline.rb:40:in `readline'
```

After applied this patch, I could run earthquake.gem on windows.

Thanks.
