### PR TITLE
run cxt.search_terminators.include? only if cxt.lastc is a String

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -3973,7 +3973,7 @@ module RbReadline
     #   variable isearch-terminators) are used to terminate the search but
     #   not subsequently execute the character as a command.  The default
     #   value is "\033\012" (ESC and C-J).
-    if (cxt.search_terminators.include?(cxt.lastc.to_s))
+    if (cxt.lastc.class == String && cxt.search_terminators.include?(cxt.lastc))
       # ESC still terminates the search, but if there is pending
       #input or if input arrives within 0.1 seconds (on systems
       #with select(2)) it is used as a prefix character


### PR DESCRIPTION
The problem is that cxt.lastc can hold both a Numeric (see lines
3954-3970) and a String. blame-ing the code as to why leads to a
deadend. But if we return to the original C readline library, we find
something similar [1]:

>  /\* The characters in isearch_terminators (set from the user-settable
>     variable isearch-terminators) are used to terminate the search but
>     not subsequently execute the character as a command.  The default
>     value is "\033\012" (ESC and C-J). _/
>  if (cxt->lastc > 0 && strchr (cxt->search_terminators, cxt->lastc))
>    {
>      /_ ESC still terminates the search, but if there is pending
>    input or if input arrives within 0.1 seconds (on systems
>    with select(2)) it is used as a prefix character
>    with rl_execute_next.  WATCH OUT FOR THIS!  This is intended

Thus, evaluating the `if` when ctx.lastc is a String is truer to the
original meaning, compared to evalutating always with the String
representation of ctx.lastc, as done in
0f2cc1390ce11dd88f85b34aaebf9b1b12dbf5f9.

[1] http://git.savannah.gnu.org/cgit/readline.git/tree/isearch.c?id=9922d2d#n381
