### PR TITLE
Improve inserting text performance

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -8503,13 +8503,33 @@ module RbReadline
 
     case @encoding
     when 'E'
-      pos = string.scan(/./me).inject(0){|r,x| r<point ? r += x.length : r }
+      x = string.scan(/./me)
+      i, len = 0, x.length
+      while (pos < point && i < len)
+        pos += x[i].length
+        i += 1
+      end
     when 'S'
-      pos = string.scan(/./ms).inject(0){|r,x| r<point ? r += x.length : r }
+      x = string.scan(/./ms)
+      i, len = 0, x.length
+      while (pos < point && i < len)
+        pos += x[i].length
+        i += 1
+      end
     when 'U'
-      pos = string.scan(/./mu).inject(0){|r,x| r<point ? r += x.length : r }
+      x = string.scan(/./mu)
+      i, len = 0, x.length
+      while (pos < point && i < len)
+        pos += x[i].length
+        i += 1
+      end
     when 'X'
-      pos = string.dup.force_encoding(@encoding_name).chars.inject(0){|r,x| r<point ? r += x.bytesize : r }
+      str = string.dup.force_encoding(@encoding_name)
+      i, len = 0, str.length
+      while (pos < point && i < len)
+        pos += str[i].bytesize
+        i += 1
+      end
     else
       pos = point
     end


### PR DESCRIPTION
This is same issue as #11. I also see this issue for a long time.
I found a way to improve it for MRI 1.9.

Ruby uses high CPU and causes low performance when inserting text on
irb. This seems to affect especially slow CPU machine.
From profiling results using ruby-prof, I found chars and inject methods
in _rl_adjust_point take long time. I rewrote it by inexpensive way.
But Ruby 1.8 performance is still slow because String#scan takes long.
