### PR TITLE
Added Readline::point() corresponding to GNU Readline's.

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -1103,7 +1103,8 @@ module RbReadline
     :rl_basic_word_break_characters,:rl_completer_quote_characters,
     :rl_completer_word_break_characters,:rl_completion_append_character,
     :rl_filename_quote_characters,:rl_instream,:rl_library_version,:rl_outstream,
-    :rl_readline_name,:history_length,:history_base
+    :rl_readline_name,:history_length,:history_base,
+    :rl_point
 
   module_function
 

--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -305,6 +305,12 @@ module Readline
     end
   end
 
+  # Returns the current offset in the current input line.
+  #
+  def self.point()
+    RbReadline.rl_point
+  end
+
   # The History class encapsulates a history of all commands entered by
   # users at the prompt, providing an interface for inspection and retrieval
   # of all commands.


### PR DESCRIPTION
Exposes @rl_point and provides Readline::point to access as per normal Ruby Readline.
