### PR TITLE
Hi, rake install would not work unless I added the .gem on the end of the filename at line 56. Maybe there is something else afoot in rubygems but this worked for me and now I can install this gem on all of my systems that need Ruby readline support.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ end
 desc "Install the gem locally"
 task :install => :gem do
   Dir.chdir(File.dirname(__FILE__)) do
-    sh %{gem install --local pkg/#{spec.name}-#{spec.version}}
+    sh %{gem install --local pkg/#{spec.name}-#{spec.version}.gem}
   end
 end
 


### PR DESCRIPTION
gem install --local pkg/rb-readline-0.5.0.pre.1
ERROR:  Could not find a valid gem 'pkg/rb-readline-0.5.0.pre.1' (>= 0) in any repository

What seems to be the cause:
It appears that an incorrect file name was used in Rakefile.

How are you fixing it:
Fixing rake install error by adding .gem to the filename at line 56
call to sh <gem file name>

Thanks for the great gem.
