### PR TITLE
Raise an error if requiring rbreadline without ENV["HOME"]

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -1091,8 +1091,8 @@ module RbReadline
   @current_readline_init_lineno = 0
 
   ENV["HOME"] ||= "#{ENV["HOMEDRIVE"]}#{ENV["HOMEPATH"]}"
-  if ENV["HOME"].empty?
-    raise RuntimeError.new("HOME environment variable (or HOMEDRIVE and HOMEPATH) must be set")
+  if !File.directory? ENV["HOME"]
+    raise RuntimeError.new("HOME environment variable (or HOMEDRIVE and HOMEPATH) must be set and point to a directory")
   end
 
   @directory = nil


### PR DESCRIPTION
No longer crash with a "can't add nil" error when importing rbreadline when ENV["HOME"], ENV["HOMEDRIVE"] and ENV["HOMEPATH"] are unset. This is a fairly common case when deploying a Rails app with something like upstart on ubuntu.

Now, at require time, it checks both to see if HOME is set and that it points to a directory, raising a comprehensible exception otherwise.

Signed-off-by: Mark Somerville mark@scottishclimbs.com
