### PR TITLE
Documentation for non-vis characters in prompt

### DIFF
--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -24,6 +24,11 @@ module Readline
   # Because this is meant as an interactive console interface, they should
   # generally not be redirected.
   #
+  # If you would like to add non-visible characters to the the prompt (for 
+  # example to add colors) you must prepend the character \001 (^A) before 
+  # each sequence of non-visible characters and add the character \002 (^B)
+  # after, otherwise line wrapping may not work properly.
+  #
   # Example:
   #
   #    loop{ Readline.readline('> ') }


### PR DESCRIPTION
Added a note in the documentation for the readline method regarding
how to add non-visible characters in a way that won't break line
wrapping.
