### PR TITLE
Fix bug when used with pry-remote(drb environment).

### DIFF
--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -89,7 +89,7 @@ module Readline
   #    Readline.completion_proc = proc{ |s| list.grep( /^#{Regexp.escape(s)}/) }
   #
   def self.completion_proc=(proc)
-    unless defined? proc.call
+    unless proc.respond_to? :call
       raise ArgumentError,"argument must respond to `call'"
     end
     @completion_proc = proc


### PR DESCRIPTION
See https://github.com/Mon-Ouie/pry-remote/issues/49 .
When we translate Proc object with drb, proc is wrapped with DRbObject.
In this case defined? proc.call is not delegated to proc self.
But proc.respond_to? :call is delegated to proc self.
So here it is better to check `proc.respond_to? :call`.
