### PR TITLE
Fix Option-Delete on OS X

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -466,6 +466,7 @@ module RbReadline
       "\ey" => :rl_yank_pop  ,
       "\e~" => :rl_tilde_expand  ,
       "\377" => :rl_backward_kill_word  ,
+      "\e\x7F" => :rl_backward_kill_word,
 
       "\C-x\C-g" => :rl_abort  ,
       "\C-x\C-r" => :rl_re_read_init_file  ,


### PR DESCRIPTION
This is a bit of a doozy to explain because of terminology differences, but here goes...

The keystroke that a Mac user would call "Option-Delete" is logically the same keystroke that a Windows user would call "Alt-Backspace" or a Unix user might call "Meta-Backspace". (For the curious, Windows's "Delete" is  "Forward Delete" on the Mac.)

A Readline user would expect this key to run `backward-kill-word` (based on it running the command of the same name in Emacs). This works in GNU Readline on OS X but fails under rb-readline.

The reason for the failure is that the Backspace key on Windows sends the `^H` (0x08) key code, and OS X (by default) sends `^?` (0x7F). On Linux it tends to be a matter of configuration ([and often confusion](http://www.tldp.org/HOWTO/Keyboard-and-Console-HOWTO-5.html)) as to which one is used.

As you can see in the "Default Key Bindings" section of [the man page](http://linux.die.net/man/3/readline), GNU Readline sidesteps the issue entirely by binding the equivalent key codes (here using Emacs key notation) to the same commands:

```
Emacs Standard bindings

    ...
"C-H"  backward-delete-char
    ...
"C-?"  backward-delete-char

Emacs Meta bindings

    ...
"M-C-H"  backward-kill-word
    ...
"M-C-?"  backward-kill-word
```

rb-readline is missing the final binding, so my patch adds it back in.

Here are sample sessions typing "one two" and then the keystroke in question:

``` irb
$ git branch -v
  fix-opt-delete 578b6b3 Bind M-C-? to `rl_backward_kill_word`
* master         ce4908d Merge pull request #102 from yui-knk/fix-completion_proc
$ ruby -Ilib -S irb
irb(main):001:0> one two^[^?
```

``` irb
$ git branch -v         
* fix-opt-delete 578b6b3 Bind M-C-? to `rl_backward_kill_word`
  master         ce4908d Merge pull request #102 from yui-knk/fix-completion_proc
$ ruby -Ilib -S irb
irb(main):001:0> one 
```
