### PR TITLE
Add `next-history` / `previous-history` to `rl_named_function`

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -2362,6 +2362,8 @@ module RbReadline
       return :rl_rubout_or_delete
     when "kill-whole-line"
       return :rl_kill_full_line
+    when "next-history"
+      return :rl_get_next_history
     when "non-incremental-forward-search-history"
       return :rl_noninc_forward_search
     when "non-incremental-reverse-search-history"
@@ -2372,6 +2374,8 @@ module RbReadline
       return :rl_noninc_reverse_search_again
     when "redraw-current-line"
       return :rl_refresh_line
+    when "previous-history"
+      return :rl_get_previous_history
     when "self-insert"
       return :rl_insert
     when "undo"


### PR DESCRIPTION
These are the original names of the commands in GNU Readline. Adding these aliases allows existing `.inputrc` files which reference these commands to work properly (even more important considering #106).

I also went through the docs for GNU Readline and compared it to the rb-readline source code, and after applying this patch, these are the only remaining GNU Readline commands which are not present in this project:

```
copy-backward-word
copy-forward-word
do-uppercase-version
dump-functions
dump-macros
dump-variables
end-of-file
history-search-backward (not the same as backward-search-history)
history-search-forward (not the same as forward-search-history)
history-substr-search-backward
history-substr-search-forward
kill-region
menu-complete
menu-complete-backward
prefix-meta
print-last-kbd-macro
skip-csi-sequence
```
