### PR TITLE
Stack track during tab completion

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -8434,6 +8434,8 @@ module RbReadline
 
     if (@rl_filename_completion_desired)
       filename = File.expand_path(text)
+      return temp_string_index unless File.exists? filename
+
       s = (nontrivial_match && !@rl_completion_mark_symlink_dirs) ?
         File.lstat(filename) : File.stat(filename)
       if s.directory?


### PR DESCRIPTION
This should work around a crash we are seeing in Metasploit:
- https://github.com/rapid7/metasploit-framework/issues/4240

`append_match` is being called with an incomplete pathname, so the error may be further upstream.
