### PR TITLE
Win fixes

### DIFF
--- a/examples/sire.rb
+++ b/examples/sire.rb
@@ -1,0 +1,78 @@
+# coding: utf-8
+# A Simple Interactive Ruby Environment
+
+require 'pp'
+
+if ARGV[0] == 'local'
+  module Readline
+    FORCE_REQUIRE_RELATIVE = true
+  end
+
+  require_relative '../lib/readline'
+else
+  require 'readline'
+end
+
+class SIRE
+  #Set up the interactive session.
+  def initialize
+    @_done = false
+  end
+
+  #Quit the interactive session.
+  def q
+    @_done = true
+    puts
+    "Quit command."
+  end
+
+  #Test spawning a process. This breaks the readline gem.
+  #For example try $run "ls"
+  def run(command)
+    IO.popen(command, "r+") do |io|
+      io.close_write
+      return io.read.split
+    end
+  end
+
+  #Execute a single line.
+  def exec_line(line)
+    result = eval line
+    pp result unless line.length == 0
+
+  rescue Interrupt => e
+    puts "\nExecution Interrupted!"
+    puts "\n#{e.class} detected: #{e}\n"
+    puts e.backtrace
+    puts "\n"
+
+  rescue Exception => e
+    puts "\n#{e.class} detected: #{e}\n"
+    puts e.backtrace
+    puts
+  end
+
+  #Run the interactive session.
+  def run_sire
+    puts
+    puts "Welcome to a Simple Interactive Ruby Environment"
+    puts
+    puts "rb-readline version = #{RbReadline::RB_READLINE_VERSION}"
+    puts
+    puts "Use the command 'q' to quit."
+    puts "To see the console handle issue try: run 'ls'"
+    puts
+    puts
+
+    until @_done
+      exec_line(Readline.readline("SIRE>", true))
+    end
+
+    puts "\n\n"
+  end
+
+end
+
+if __FILE__ == $0
+  SIRE.new.run_sire
+end

--- a/examples/sire.rb
+++ b/examples/sire.rb
@@ -4,10 +4,6 @@
 require 'pp'
 
 if ARGV[0] == 'local'
-  module Readline
-    FORCE_REQUIRE_RELATIVE = true
-  end
-
   require_relative '../lib/readline'
 else
   require 'readline'

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -8,7 +8,11 @@
 #  Copyright (C) 2009 by Park Heesob phasis@gmail.com
 #
 
-require "rbreadline/version"
+if defined? Readline::FORCE_REQUIRE_RELATIVE
+  require_relative "rbreadline/version"
+else
+  require "rbreadline/version"
+end
 
 class Fixnum
   def ord; self; end
@@ -4424,7 +4428,13 @@ module RbReadline
     @MessageBeep = Win32API.new("user32","MessageBeep",['L'],'L')
     @GetKeyboardState = Win32API.new("user32","GetKeyboardState",['P'],'L')
     @GetKeyState = Win32API.new("user32","GetKeyState",['L'],'L')
-    @hConsoleHandle = @GetStdHandle.Call(STD_OUTPUT_HANDLE)
+
+    def rl_refresh_console_handle
+      @hConsoleHandle = @GetStdHandle.Call(STD_OUTPUT_HANDLE)
+    end
+
+    rl_refresh_console_handle
+
     @hConsoleInput =  @GetStdHandle.Call(STD_INPUT_HANDLE)
     @pending_count = 0
     @pending_key = nil
@@ -4499,6 +4509,9 @@ module RbReadline
       k = send(@rl_getc_function,@rl_instream)
       rl_stuff_char(k)
       return 1
+    end
+
+    def rl_refresh_console_handle
     end
   end
 

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -8,11 +8,11 @@
 #  Copyright (C) 2009 by Park Heesob phasis@gmail.com
 #
 
-if defined? Readline::FORCE_REQUIRE_RELATIVE
-  require_relative "rbreadline/version"
-else
+#if defined? Readline::FORCE_REQUIRE_RELATIVE
+#  require_relative "rbreadline/version"
+#else
   require "rbreadline/version"
-end
+#end
 
 class Fixnum
   def ord; self; end

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -2474,6 +2474,17 @@ module RbReadline
       rl_bind_keyseq_if_unbound("\340t", :rl_forward_word) # Ctrl-Right
       rl_bind_keyseq_if_unbound("\340S", :rl_delete) # Delete
       rl_bind_keyseq_if_unbound("\340R", :rl_overwrite_mode) # Insert
+
+      rl_bind_keyseq_if_unbound("\x00H", :rl_get_previous_history) # Up
+      rl_bind_keyseq_if_unbound("\x00P", :rl_get_next_history) # Down
+      rl_bind_keyseq_if_unbound("\x00M", :rl_forward_char)  # Right
+      rl_bind_keyseq_if_unbound("\x00K", :rl_backward_char) # Left
+      rl_bind_keyseq_if_unbound("\x00G", :rl_beg_of_line)   # Home
+      rl_bind_keyseq_if_unbound("\x00O", :rl_end_of_line)   # End
+      rl_bind_keyseq_if_unbound("\x00s", :rl_backward_word) # Ctrl-Left
+      rl_bind_keyseq_if_unbound("\x00t", :rl_forward_word) # Ctrl-Right
+      rl_bind_keyseq_if_unbound("\x00S", :rl_delete) # Delete
+      rl_bind_keyseq_if_unbound("\x00R", :rl_overwrite_mode) # Insert
     else
       rl_bind_keyseq_if_unbound("\033[A", :rl_get_previous_history)
       rl_bind_keyseq_if_unbound("\033[B", :rl_get_next_history)

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -8,11 +8,11 @@
 #  Copyright (C) 2009 by Park Heesob phasis@gmail.com
 #
 
-#if defined? Readline::FORCE_REQUIRE_RELATIVE
-#  require_relative "rbreadline/version"
-#else
+if private_methods.include? :require_relative
+  require_relative "rbreadline/version"
+else
   require "rbreadline/version"
-#end
+end
 
 class Fixnum
   def ord; self; end

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -21,8 +21,8 @@ end
 module RbReadline
   require 'etc'
 
-  RL_LIBRARY_VERSION = "5.2"
-  RL_READLINE_VERSION  = 0x0502
+  RL_LIBRARY_VERSION = "5.4"
+  RL_READLINE_VERSION  = 0x0504
 
   EOF = "\xFF"
   ESC = "\C-["

--- a/lib/rbreadline/version.rb
+++ b/lib/rbreadline/version.rb
@@ -1,3 +1,3 @@
 module RbReadline
-  RB_READLINE_VERSION = "0.5.3"
+  RB_READLINE_VERSION = "0.5.4"
 end

--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -7,11 +7,11 @@
 
 module Readline
 
-  if defined? FORCE_REQUIRE_RELATIVE
-    require_relative 'rbreadline'
-  else
+#  if defined? FORCE_REQUIRE_RELATIVE
+#    require_relative 'rbreadline'
+#  else
     require 'rbreadline'
-  end
+#  end
 
   include RbReadline
 

--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -7,7 +7,12 @@
 
 module Readline
 
-  require 'rbreadline'
+  if defined? FORCE_REQUIRE_RELATIVE
+    require_relative 'rbreadline'
+  else
+    require 'rbreadline'
+  end
+
   include RbReadline
 
   @completion_proc = nil
@@ -24,8 +29,8 @@ module Readline
   # Because this is meant as an interactive console interface, they should
   # generally not be redirected.
   #
-  # If you would like to add non-visible characters to the the prompt (for 
-  # example to add colors) you must prepend the character \001 (^A) before 
+  # If you would like to add non-visible characters to the the prompt (for
+  # example to add colors) you must prepend the character \001 (^A) before
   # each sequence of non-visible characters and add the character \002 (^B)
   # after, otherwise line wrapping may not work properly.
   #
@@ -40,6 +45,7 @@ module Readline
 
     RbReadline.rl_instream = $stdin
     RbReadline.rl_outstream = $stdout
+    RbReadline.rl_refresh_console_handle
 
     begin
       buff = RbReadline.readline(prompt)

--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -7,11 +7,11 @@
 
 module Readline
 
-#  if defined? FORCE_REQUIRE_RELATIVE
-#    require_relative 'rbreadline'
-#  else
+  if private_methods.include? :require_relative
+    require_relative 'rbreadline'
+  else
     require 'rbreadline'
-#  end
+  end
 
   include RbReadline
 

--- a/test/test_rbreadline.rb
+++ b/test/test_rbreadline.rb
@@ -3,8 +3,8 @@ require 'rbreadline'
 
 class TestRbReadline < Minitest::Test
   def test_versions
-    assert_equal('5.2', RbReadline::RL_LIBRARY_VERSION)
-    assert_equal(0x0502, RbReadline::RL_READLINE_VERSION)
+    assert_equal('5.4', RbReadline::RL_LIBRARY_VERSION)
+    assert_equal(0x0504, RbReadline::RL_READLINE_VERSION)
   end
 
   def test_rl_adjust_point

--- a/test/test_readline.rb
+++ b/test/test_readline.rb
@@ -7,7 +7,7 @@ class TestReadline < Minitest::Test
   end
 
   def test_version
-    assert_equal('5.2', Readline::VERSION)
+    assert_equal('5.4', Readline::VERSION)
   end
 
   def test_readline_basic


### PR DESCRIPTION
This pull request addresses two problematic areas encountered when using the readline gem under a Windows environment. 

NOTE: To facilitate testing, the program sire.rb has been added to the examples folder. This is a simple REPL that has some added test facilities (see below)

1) The @hConsoleHandle is not a constant, but can change. The existing code gets this handle but once, when loaded, and falls apart when it does change. In particular the IO.popen method can cause this to happen. To test this with the existing gem, use

> C:\Sites\rb-readline>ruby examples/sire.rb

The the run command will exercise IO.popen

> SIRE>run 'ls'
> ["CHANGES",
>  "Gemfile",
> ... etc etc etc
>  "test"]

After this point, command entry will no longer work correctly with the existing gem. The corrected gem refreshes the console handle on each call and encounters no issues. A stub is placed in the Unix code area so this change does not impact those platforms.

2) While the keyboard mappings for "legacy" keys are included for Unix platforms, they are omitted for Windows. This causes distress in a number of cases, especially keyboards designed for special needs which use these older mappings. In addition, all Windows keyboards use these key codes for some keys. This patch defines all appropriate key mappings for Windows platforms. This change does not impact Unix platforms.

Non-windows conformance has been tested under Cygwin. At this time I lack access to other platforms. I am open to any suggestions that would the enhance quality of this code and hope to hear your thoughts in this regard.

Best regards; Peter Camilleri
