### PR TITLE
Update and rename README.rdoc to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,38 @@
-= Description
+# Description
 
 The readline library provides a pure Ruby implementation of the GNU
 readline C library, as well as the Readline extension that ships as part
 of the standard library.
 
-= Synopsis
+## Installation
 
-  require 'readline'
+    gem install rb-readline
+  
+Or in a `Gemfile`:
+  
+    gem 'rb-readline'
 
-  loop do
-    line = Readline::readline('> ')
-    break if line.nil? || line == 'quit'
-    Readline::HISTORY.push(line)
-    puts "You typed: #{line}"
-  end
+## Synopsis
 
-= Compatibility
+```ruby
+require 'readline'
+
+loop do
+  line = Readline::readline('> ')
+  break if line.nil? || line == 'quit'
+  Readline::HISTORY.push(line)
+  puts "You typed: #{line}"
+end
+```
+
+## Compatibility
 
 rb-readline should work on all Unix-like systems and Windows. It is regularly
 used with MRI 1.8/1.9 and Rubinius. JRuby is not supported and there are no
 plans to support it in the future - it comes bundled with a Java implementation
 of Readline.
 
-= Motivation
+## Motivation
 
 First, building the GNU readline library on MS Windows with Visual C++ is
 almost impossible. However, certain libraries depend on readline. By providing
@@ -47,7 +57,7 @@ weak, and only provides a very limited subset of the actual GNU readline
 library. By providing a pure Ruby implementation we allow 3rd party library
 authors to write their own interface as they see fit.
 
-= Tutorial
+## Tutorial
 
 For an excellent tutorial on how to use Readline in practice, please see
 Joseph Pecoraro's examples at http://bogojoker.com/readline/.
@@ -55,14 +65,14 @@ Joseph Pecoraro's examples at http://bogojoker.com/readline/.
 You can also take a look at Ruby 1.9 stdlib Readline documentation located
 at http://rubydoc.info/stdlib/readline/1.9.2/frames
 
-= Alternatives
+## Alternatives
 
 See Rawline for a library that began life in pure Ruby and provides an
 interface that's probably more comfortable to Ruby programmer. It has certain
 features that Readline does not. In addition, it provides a Readline
 compatibility mode.
 
-= Authors
+## Authors
 
 * Park Heesob (C translation, code donated as part of bounty)
 * Daniel Berger (Documentation and testing)


### PR DESCRIPTION
Add installation instructions.

----

With ruby building without readline support, this library is getting quite popular 👍 .