### PR TITLE
Fix NilClass error when stdin is not a terminal

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -7016,7 +7016,7 @@ module RbReadline
 
     setting << " -ixoff"
 
-    rl_bind_key(@_rl_tty_chars.t_start, :rl_restart_output)
+    rl_bind_key(@_rl_tty_chars.t_start, :rl_restart_output) unless @_rl_tty_chars.t_start.nil?
     @_rl_eof_char = @_rl_tty_chars.t_eof
 
     #setting << " -isig"


### PR DESCRIPTION
In some cases, such as when running tests under minitest, stdin
can get remapped in such a way that shell-outs to commands like
`stty -a` will report "stdin is not a terminal". This can cause
the elements in @_rl_tty_chars to be nil.

In #prepare_terminal_settings, rl_bind_key is called for function
:rl_restart_output, but if @_rl_tty_chars.t_start is nil,
StringScanner.new(seq) in rl_translate_keyseq will throw:

```
Error: no implicit conversion of nil into String
```

This appears to be the only case in the codebase where an unguarded
call to rl_bind_key exists, so this change ensures that we do not
try and map a nil key to :rl_restart_output.

Signed-off-by: Adam Leff <adam@leff.co>