### PR TITLE
reassign Readline constants

### DIFF
--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -316,6 +316,16 @@ module Readline
     RbReadline.rl_point
   end
 
+  # Temporarily disable warnings and call a block
+  #
+  def self.silence_warnings(&block)
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    result = block.call
+    $VERBOSE = warn_level
+    result
+  end
+
   # The History class encapsulates a history of all commands entered by
   # users at the prompt, providing an interface for inspection and retrieval
   # of all commands.
@@ -455,7 +465,7 @@ module Readline
 
   end
 
-  HISTORY = History unless const_defined? :HISTORY
+  silence_warnings { HISTORY = History }
 
   # The Fcomp class provided to encapsulate typical filename completion
   # procedure. You will not typically use this directly, but will instead
@@ -483,7 +493,7 @@ module Readline
     end
   end
 
-  FILENAME_COMPLETION_PROC = Fcomp unless const_defined? :FILENAME_COMPLETION_PROC
+  silence_warnings { FILENAME_COMPLETION_PROC = Fcomp }
 
   # The Ucomp class provided to encapsulate typical filename completion
   # procedure. You will not typically use this directly, but will instead
@@ -514,13 +524,13 @@ module Readline
     end
   end
 
-  USERNAME_COMPLETION_PROC = Ucomp unless const_defined? :USERNAME_COMPLETION_PROC
+  silence_warnings { USERNAME_COMPLETION_PROC = Ucomp }
 
   RbReadline.rl_readline_name = "Ruby"
 
   RbReadline.using_history()
 
-  VERSION = RbReadline.rl_library_version unless const_defined? :VERSION
+  silence_warnings { VERSION = RbReadline.rl_library_version }
 
   module_function :readline
 


### PR DESCRIPTION
Hello all

https://github.com/ConnorAtherton/rb-readline/pull/131 was merged , 
so now can not get history command using up and down arrow in ruby-pry console. ^^ 

This is my test Gemfile  : 
```
source 'https://rubygems.org'
gem 'pry'
gem 'rb-readline', '0.5.4'
```

> bundle exec pry
>  　#  up/down arrow not working

This is module load steps:
1. load pry
    1.1 load the native `readline` (see [lib/pry/config/default.rb](https://github.com/pry/pry/blob/master/lib/pry/config/default.rb#L139) )
1. load rb-readline
    2.1 can not overwrite `Readline::HISTORY` because it defined in native readline (see [here](https://github.com/ConnorAtherton/rb-readline/pull/131/files#diff-c310173f7181bcd00ee63400c1d6c8ddL458))

So the warning `warning: already initialized constant Readline::HISTORY` is not a problem,
we should be reassign Readline constants as rb-readline class.

------------

PS: This Gemfile is working , and `already initialized constant` warnings will not be displayed.
```
source 'https://rubygems.org'
gem 'pry'
gem 'rb-readline', github: 'dulao5/rb-readline', branch: 'reassign_readline_constants'
```

