### PR TITLE
Update to run when connected to a pipe

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -16,6 +16,7 @@ end
 
 module RbReadline
   require 'etc'
+  require 'io/console'
 
   RL_LIBRARY_VERSION = "5.2"
   RL_READLINE_VERSION  = 0x0502
@@ -1091,6 +1092,9 @@ module RbReadline
   @current_readline_init_file = nil
   @current_readline_init_include_level = 0
   @current_readline_init_lineno = 0
+
+  # Used in windows 
+  @is_pipe = false
 
   ENV["HOME"] ||= "#{ENV["HOMEDRIVE"]}#{ENV["HOMEPATH"]}"
   if !File.directory? ENV["HOME"]
@@ -4490,6 +4494,10 @@ module RbReadline
     end
 
     def rl_getc(stream)
+      # below added as test for whether we're connected to a pipe or a keyboard.
+      # Pipe connection is probably running under a test suite.
+      return (stream.getc || EOF rescue EOF) if @is_pipe
+
       while (@kbhit.Call == 0)
         # If there is no input, yield the processor for other threads
         sleep(@_keyboard_input_timeout)
@@ -4740,6 +4748,7 @@ module RbReadline
   def readline_internal_charloop()
     lastc = -1
     eof_found = false
+    @is_pipe = (!@rl_outstream.winsize rescue true)
 
     while (!@rl_done)
       lk = @_rl_last_command_was_kill


### PR DESCRIPTION
New work being done on Byebug showed that using rb-readline with pipes for input & output odes not function, as windows code defaults to keyboard API's.

This is not uncommon with testing, and it is one of the reasons rb-readline does poorly with ruby's readline tests.  More fixes for that later.

This uses io/console's winsize attribute to determine this, and changes behavior accordingly.