### PR TITLE
Fix ruby warnings such as unused variable and extra space in method definition

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -5584,7 +5584,6 @@ module RbReadline
 
     if @rl_byte_oriented
       incoming << c
-      incoming_length = 1
     else
       @pending_bytes << c
       if _rl_get_char_len(@pending_bytes) == -2
@@ -5592,7 +5591,6 @@ module RbReadline
       else
         incoming = @pending_bytes
         @pending_bytes = ''
-        incoming_length = incoming.length
       end
     end
 

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -5409,7 +5409,7 @@ module RbReadline
   # Make the history entry at WHICH have LINE and DATA.  This returns
   #   the old entry so you can dispose of the data.  In the case of an
   #   invalid WHICH, a NULL pointer is returned.
-  def replace_history_entry (which, line, data)
+  def replace_history_entry(which, line, data)
     if (which < 0 || which >= @history_length)
       return nil
     end
@@ -5492,7 +5492,7 @@ module RbReadline
     0
   end
 
-  def _rl_history_set_point ()
+  def _rl_history_set_point()
     @rl_point = (@_rl_history_preserve_point && @_rl_history_saved_point != -1) ?
       @_rl_history_saved_point : @rl_end
     if (@rl_point > @rl_end)
@@ -7132,7 +7132,7 @@ module RbReadline
 
   # Kill from here to the end of the line.  If DIRECTION is negative, kill
   #   back to the line start instead.
-  def rl_kill_line (direction, ignore)
+  def rl_kill_line(direction, ignore)
     if (direction < 0)
       return (rl_backward_kill_line(1, ignore))
     else
@@ -7776,7 +7776,7 @@ module RbReadline
     0
   end
 
-  def rl_backward_char_search (count, key)
+  def rl_backward_char_search(count, key)
     _rl_char_search(count, BFIND, FFIND)
   end
 
@@ -8085,7 +8085,7 @@ module RbReadline
   end
 
   # Do an anchored search for string through the history in DIRECTION.
-  def history_search_prefix (string, direction)
+  def history_search_prefix(string, direction)
     history_search_internal(string, direction, ANCHORED_SEARCH)
   end
 


### PR DESCRIPTION
Came across these warnings while running ruby scripts with warnings turned on.

Cheers