### PR TITLE
Support non-stdin pty/pts devices: Assign the correct IO to the stty calls

### DIFF
--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -8919,7 +8919,10 @@ module RbReadline
   # calls the given program with stdin set to the input stream
   # and returns stdout
   def io_exec(args)
-    IO.popen(args, in: @rl_instream) do |io|
+    sane_config = {} # default, not stdin if @rl_instream doesn't have a file descriptor, or we might get stdin closed errors
+    sane_config[:in] = @rl_instream if @rl_instream.respond_to?(:fileno) && !@rl_instream.fileno.nil?
+
+    IO.popen(args, sane_config) do |io|
       result = String.new
       until io.eof?
         tmp = io.read

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -1812,7 +1812,7 @@ module RbReadline
 
   def get_term_capabilities(buffer)
     hash = {}
-      `infocmp -C`.split(':').select{|x| x =~ /(.*)=(.*)/ and hash[$1]=$2.gsub("\\r", "\r").gsub('\\E',"\e").gsub(/\^(.)/){($1[0].ord ^ ((?a..?z).include?($1[0]) ? 0x60 : 0x40)).chr}}
+      io_exec(%w{infocmp -C}).split(':').select{|x| x =~ /(.*)=(.*)/ and hash[$1]=$2.gsub("\\r", "\r").gsub('\\E',"\e").gsub(/\^(.)/){($1[0].ord ^ ((?a..?z).include?($1[0]) ? 0x60 : 0x40)).chr}}
       @_rl_term_at7          =     hash["@7"]
       @_rl_term_DC           =     hash["DC"]
       @_rl_term_IC           =     hash["IC"]
@@ -1868,7 +1868,7 @@ module RbReadline
     else
       wr, wc = 0
       retry_if_interrupted do
-        wr, wc = `stty size`.split(' ').map { |x| x.to_i }
+        wr, wc = io_exec(%w{stty size}).split(' ').map { |x| x.to_i }
       end
       @_rl_screenwidth = wc
       @_rl_screenheight = wr
@@ -1899,7 +1899,7 @@ module RbReadline
   end
 
   def tgetflag(name)
-      `infocmp -C -r`.scan(/\w{2}/).include?(name)
+      io_exec(%w{infocmp -C -r}).scan(/\w{2}/).include?(name)
   end
 
   # Return the function (or macro) definition which would be invoked via
@@ -2058,7 +2058,7 @@ module RbReadline
   def rl_tty_set_default_bindings(kmap)
     h = {}
     retry_if_interrupted do
-      h = Hash[*`stty -a`.scan(/(\w+) = ([^;]+);/).flatten]
+      h = Hash[*io_exec(%w{stty -a}).scan(/(\w+) = ([^;]+);/).flatten]
     end
     h.each {|k,v| v.gsub!(/\^(.)/){($1[0].ord ^ ((?a..?z).include?($1[0]) ? 0x60 : 0x40)).chr}}
     kmap[h['erase']] = :rl_rubout
@@ -4475,7 +4475,7 @@ module RbReadline
     @pending_key = nil
 
     begin
-      case `chcp`.scan(/\d+$/).first.to_i
+      case io_exec("chcp").scan(/\d+$/).first.to_i
       when 936,949,950,51932,51936,50225
         @encoding = "E"
       when 932,50220,50221,20222
@@ -6965,7 +6965,7 @@ module RbReadline
     @_rl_last_tty_chars = @_rl_tty_chars
     h = {}
     retry_if_interrupted do
-      h = Hash[*`stty -a`.scan(/(\w+) = ([^;]+);/).flatten]
+      h = Hash[*io_exec(%w{stty -a}).scan(/(\w+) = ([^;]+);/).flatten]
     end
     h.each {|k,v| v.gsub!(/\^(.)/){($1[0].ord ^ ((?a..?z).include?($1[0]) ? 0x60 : 0x40)).chr}}
     @_rl_tty_chars.t_erase = h['erase']
@@ -6985,7 +6985,7 @@ module RbReadline
     @_rl_tty_chars.t_lnext = h['lnext']
     @_rl_tty_chars.t_status = -1
     retry_if_interrupted do
-      @otio = `stty -g`
+      @otio = io_exec(%w{stty -g})
     end
   end
 
@@ -6998,7 +6998,7 @@ module RbReadline
 
   def prepare_terminal_settings(meta_flag)
     retry_if_interrupted do
-      @readline_echoing_p = (`stty -a`.scan(/-*echo\b/).first == 'echo')
+      @readline_echoing_p = (io_exec(%w{stty -a}).scan(/-*echo\b/).first == 'echo')
     end
 
     # First, the basic settings to put us into character-at-a-time, no-echo
@@ -7009,7 +7009,7 @@ module RbReadline
     #   use it for the meta-key.  If only one of even or odd parity is
     #  specified, then the terminal is using parity, and we cannot.
     retry_if_interrupted do
-      if (`stty -a`.scan(/-parenb\b/).first == '-parenb')
+      if (io_exec(%w{stty -a}).scan(/-parenb\b/).first == '-parenb')
         setting << " pass8"
       end
     end
@@ -7022,7 +7022,7 @@ module RbReadline
     #setting << " -isig"
 
     retry_if_interrupted do
-      `stty #{setting}`
+      io_exec("stty #{setting}".split " ")
     end
   end
 
@@ -7111,7 +7111,7 @@ module RbReadline
 
     # restore terminal setting
     retry_if_interrupted do
-      `stty #{@otio}`
+      io_exec("stty #{@otio}".split " ")
     end
 
     @terminal_prepped = false
@@ -8915,6 +8915,19 @@ module RbReadline
     term = ENV["TERM"]
     term.nil? || (term == 'dumb') || (RUBY_PLATFORM =~ /mswin|mingw/)
   end
-  private :no_terminal?
+
+  # calls the given program with stdin set to the input stream
+  # and returns stdout
+  def io_exec(args)
+    IO.popen(args, in: @rl_instream) do |io|
+      result = String.new
+      until io.eof?
+        tmp = io.read
+        result << tmp unless tmp.nil?
+      end
+      result
+    end
+  end
+  private :no_terminal?, :io_exec
 
 end

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -4058,7 +4058,7 @@ module RbReadline
   end
 
   def _rl_input_available
-    IO.select([ $stdin ], nil, [ $stdin ], @_keyboard_input_timeout)
+    IO.select([ @rl_instream ], nil, [ @rl_instream ], @_keyboard_input_timeout)
   end
 
   # Process just-read character C according to isearch context CXT.  Return

--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -34,12 +34,12 @@ module Readline
   #    loop{ Readline.readline('> ') }
   #
   def readline(prompt = "", add_history = nil)
-    if $stdin.closed?
+    if RbReadline.rl_instream.closed?
       raise IOError, "stdin closed"
     end
 
-    RbReadline.rl_instream = $stdin
-    RbReadline.rl_outstream = $stdout
+    RbReadline.rl_instream ||= $stdin
+    RbReadline.rl_outstream ||= $stdout
 
     begin
       buff = RbReadline.readline(prompt)


### PR DESCRIPTION
The current `stty size` calls implicitly assume the device to read from is stdin, which is not overridden when `@rl_instream` is manually set to a pts device that isn't mapped to `$stdin`. As such, when `$stdin` is a pipe or other device where `$stdin.tty? == false`, the prompt and history editing is not visible. Further, if `$stdin` is sized differently than `@rl_instream`, the size will be erroneously for `$stdin` and not `@rl_instream`. 

This PR:
 * Adds a new private method `io_exec` that correctly calls `IO.popen` with `@rl_instream` as stdin
 * Replaces all calls to backtick-launched processes with `io_exec`
 * Uses `@rl_instream` in the search-exit logic instead of hardcoding `$stdin`
 * Adds a new test to test that pty/pts devices correctly receive the prompt and visual editing. Fails on current master, passes with the other changes enclosed.

I have successfully tested this on JRuby 9.2, MRI 2.2.0, MRI 2.5.1, MRI 2.6.2 on RHEL 7.6 & Debian 9.

I have not tested this on Windows or macOS, and would appreciate anyone with such a machine testing this change, as I have limited access to such boxes.