### PR TITLE
Don't assume that readline is already loaded and fixed some warnings

### DIFF
--- a/lib/rb-readline.rb
+++ b/lib/rb-readline.rb
@@ -8,11 +8,14 @@
 # catch cases where GNU Readline has already been required. Unfortunately, it
 # is not without problems - any calls to methods like Readline.completion_proc
 # will need to be re-made.
-if (defined? Readline) && (! defined? RbReadline)
-  if $DEBUG
-    STDERR.puts "Removing old Readline module - redefined by rb-readline."
+unless defined? RbReadline
+  if defined? Readline
+    if $DEBUG
+      $stderr.puts 'Removing old Readline module - redefined by rb-readline.'
+    end
+
+    Object.send(:remove_const, :Readline)
   end
-  Object.send(:remove_const, :Readline)
+
   require File.join(File.dirname(__FILE__), 'readline')
 end
-

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -10,8 +10,10 @@
 
 require "rbreadline/version"
 
-class Integer
-  def ord; self; end
+unless Integer.instance_methods(true).include?(:ord)
+  class Integer
+    def ord; self; end
+  end
 end
 
 module RbReadline

--- a/lib/rbreadline.rb
+++ b/lib/rbreadline.rb
@@ -3484,7 +3484,7 @@ module RbReadline
         if (!@rl_byte_oriented)
           _rl_wrapped_multicolumn = 0
           if (@_rl_screenwidth < lpos + wc_width)
-            for i in lpos ... @_rl_screenwidth
+            (lpos ... @_rl_screenwidth).each do
               # The space will be removed in update_line()
               line[out,1] = ' '
               out += 1
@@ -3503,7 +3503,7 @@ module RbReadline
           end
           line[out,wc_bytes] = @rl_line_buffer[_in,wc_bytes]
           out += wc_bytes
-          for i in 0 ... wc_width
+          (0 ... wc_width).each do
             lpos+=1
             if (lpos >= @_rl_screenwidth)
               @inv_lbreaks[newlines+=1] = out

--- a/test/test_readline.rb
+++ b/test/test_readline.rb
@@ -124,8 +124,13 @@ class TestReadline < Minitest::Test
         [ "", nil ],
       ].each do |data, expected|
         Readline.completion_append_character = data
-        assert_equal(expected, Readline.completion_append_character,
-          "failed case: [#{data.inspect}, #{expected.inspect}]")
+        if expected.nil?
+          assert_nil(Readline.completion_append_character,
+                     "failed case: [#{data.inspect}, #{expected.inspect}]")
+        else
+          assert_equal(expected, Readline.completion_append_character,
+                       "failed case: [#{data.inspect}, #{expected.inspect}]")
+        end
       end
     ensure
       Readline.completion_append_character = orig_char
@@ -191,7 +196,7 @@ class TestReadline < Minitest::Test
   end
 
   def test_attempted_comp_func_returns_nil_when_no_completion_proc_set
-    assert_equal nil, Readline.readline_attempted_completion_function("12", 0, 1)
+    assert_nil Readline.readline_attempted_completion_function("12", 0, 1)
   end
 
   def test_attempted_comp_func_case_folding


### PR DESCRIPTION
This was loading lib/readline.rb only if Readline was defined and RbReadline wasn't defined.

"rake test" results get garbled and can cause strange terminal state when minitest "DEPRECATED" warning are output.